### PR TITLE
Rename report rule to category

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## UNRELEASED
+
+### Changes
+
+-   Renamed report rules to categories.
+
 ## [1.8.1] - [2022-01-2021]
 
 ### Bugfixes

--- a/src/baseTypes.ts
+++ b/src/baseTypes.ts
@@ -12,7 +12,7 @@ const DateTypeDefault = z.union([ z.string().default(() => new Date().toISOStrin
 // This exists so that creating a report doesn't need an ID and some stuff is optional
 export const CreateReport = z.object({
 	playername: z.string(),
-	brokenRule: z.string(),
+	categoryId: z.string(),
 	proof: z.string().default("No proof"),
 	description: z.string().default("No description"),
 	automated: z.boolean().default(false),
@@ -41,22 +41,22 @@ export const Community = z.object({
 }).merge(Common)
 export type Community = z.infer<typeof Community>
 
-export const Rule = z.object({
+export const Category = z.object({
 	shortdesc: z.string(),
 	longdesc: z.string(),
 }).merge(Common)
-export type Rule = z.infer<typeof Rule>
+export type Category = z.infer<typeof Category>
 
 export const GuildConfig = z.object({
 	guildId: z.string(),
 	communityId: z.string().optional(),
 	trustedCommunities: z.array(z.string()).default([]),
-	ruleFilters: z.array(z.string()).default([]),
+	categoryFilters: z.array(z.string()).default([]),
 	roles: z.object({
 		reports: z.string().default(""),
 		webhooks: z.string().default(""),
 		setConfig: z.string().default(""),
-		setRules: z.string().default(""),
+		setCategories: z.string().default(""),
 		setCommunities: z.string().default(""),
 	}),
 	apiKey: z.string().nullable().optional(),

--- a/src/websocketMessages.ts
+++ b/src/websocketMessages.ts
@@ -1,11 +1,11 @@
 import { APIEmbed, APIUser } from "discord-api-types"
 import { z } from "zod"
-import { Community, GuildConfig, Report, Revocation, Rule } from "./baseTypes"
+import { Category, Community, GuildConfig, Report, Revocation } from "./baseTypes"
 
 export const BaseWebsocketMessage = z.object({
 	messageType: z.enum([
 		"report", "revocation",
-		"ruleCreated", "ruleRemoved", "ruleUpdated", "rulesMerged",
+		"categoryCreated", "categoryRemoved", "categoryUpdated", "categoriesMerged",
 		"communityCreated", "communityRemoved", "communityUpdated", "communitiesMerged",
 		"guildConfigChanged",
 		"announcement" ]),
@@ -15,7 +15,7 @@ export type BaseWebsocketMessage = z.infer<typeof BaseWebsocketMessage>
 export const ReportMessageExtraOpts = z.object({
 	community: Community,
 	createdBy: z.object({}).passthrough(), // no way to validate this
-	rule: Rule,
+	category: Category,
 	totalReports: z.number(),
 	totalCommunities: z.number(),
 })
@@ -42,33 +42,33 @@ export const RevocationMessage = z.object({
 }).merge(BaseWebsocketMessage)
 export type RevocationMessage = z.infer<typeof RevocationMessage> & { embed: APIEmbed }
 
-export const RuleCreatedMessage = z.object({
-	messageType: z.literal("ruleCreated"),
+export const CategoryCreatedMessage = z.object({
+	messageType: z.literal("categoryCreated"),
 	embed: z.object({}).passthrough(), // no way to validate this
-	rule: Rule,
+	category: Category,
 }).merge(BaseWebsocketMessage)
-export type RuleCreatedMessage = z.infer<typeof RuleCreatedMessage> & { embed: APIEmbed }
+export type CategoryCreatedMessage = z.infer<typeof CategoryCreatedMessage> & { embed: APIEmbed }
 
-export const RuleRemovedMessage = z.object({
-	messageType: z.literal("ruleRemoved"),
+export const CategoryRemovedMessage = z.object({
+	messageType: z.literal("categoryRemoved"),
 	embed: z.object({}).passthrough(), // no way to validate this
-	rule: Rule,
+	category: Category,
 }).merge(BaseWebsocketMessage)
-export type RuleRemovedMessage = z.infer<typeof RuleRemovedMessage> & { embed: APIEmbed }
+export type CategoryRemovedMessage = z.infer<typeof CategoryRemovedMessage> & { embed: APIEmbed }
 
-export const RuleUpdatedMessage = z.object({
-	messageType: z.literal("ruleUpdated"),
+export const CategoryUpdatedMessage = z.object({
+	messageType: z.literal("categoryUpdated"),
 	embed: z.object({}).passthrough(), // no way to validate this
-	rule: Rule,
+	category: Category,
 }).merge(BaseWebsocketMessage)
-export type RuleUpdatedMessage = z.infer<typeof RuleUpdatedMessage> & { embed: APIEmbed }
+export type CategoryUpdatedMessage = z.infer<typeof CategoryUpdatedMessage> & { embed: APIEmbed }
 
-export const RulesMergedMessage = z.object({
-	messageType: z.literal("rulesMerged"),
+export const CategoriesMergedMessage = z.object({
+	messageType: z.literal("categoriesMerged"),
 	embed: z.object({}).passthrough(), // no way to validate this
-	rules: Rule,
+	categories: Category,
 }).merge(BaseWebsocketMessage)
-export type RulesMergedMessage = z.infer<typeof RulesMergedMessage> & { embed: APIEmbed }
+export type CategoriesMergedMessage = z.infer<typeof CategoriesMergedMessage> & { embed: APIEmbed }
 
 export const CommunityCreatedMessageExtraOpts = z.object({
 	createdBy: z.object({}).passthrough(), // no way to validate this


### PR DESCRIPTION
The report rules function more as a categorization of reports than rules
and the name "rule" is somewhat confusing as they are not the rules of
any particular community or server.

Please see FactorioAntigrief/fagc-backend#320.